### PR TITLE
create the server-runtime the babel plugin uses

### DIFF
--- a/packages/custom-elements/src/index.ts
+++ b/packages/custom-elements/src/index.ts
@@ -1,10 +1,12 @@
+import type { AnyFunction } from "./utils/types";
+
 import "./core";
 import "./let-signal";
 import "./signal-html";
 
 declare global {
 	interface Window {
-		__FNS__: Record<string, Function>;
+		__FNS__: Record<string, AnyFunction>;
 	}
 }
 

--- a/packages/custom-elements/src/utils/types.ts
+++ b/packages/custom-elements/src/utils/types.ts
@@ -13,10 +13,11 @@ export enum SOLENOID_OBJECT_TYPES {
 
 // ---------------------------------------------------
 
-export type SolenoidFunctionConfig = {
+export type SolenoidFunctionConfig<Closure extends any[] = any[]> = {
 	[SOLENOID_CUSTOM_KEY]: SOLENOID_OBJECT_TYPES.Function;
+	id: string;
 	module: string;
-	closure: unknown[];
+	closure: ()=>Closure;
 };
 
 export type SolenoidSignalConfig = {

--- a/packages/server-runtime/package.json
+++ b/packages/server-runtime/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@solenoid/runtime",
+	"name": "@solenoid/server-runtime",
 	"version": "0.0.0",
 	"description": "Runtime for rendering on the server. TBD",
 	"main": "lib/index.js",
@@ -11,5 +11,10 @@
 		"test": "vitest"
 	},
 	"dependencies": {},
-	"devDependencies": {}
+	"peerDependencies": {
+		"@solenoid/custom-elements": "^0.0.0"
+	},
+	"devDependencies": {
+		"@solenoid/custom-elements": "^0.0.0"
+	}
 }

--- a/packages/server-runtime/src/__tests__/index.test.ts
+++ b/packages/server-runtime/src/__tests__/index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { serializableFn } from "..";
+
+describe('server-runtime', ()=>{
+  describe('serializableFn', ()=>{
+    test('works on overloaded functions', ()=>{
+      function build<T extends string>(param: T): {str: T};
+      function build<T extends number>(param: T): {num: T};
+      function build<T extends string | number>(param: T) {
+        if (typeof param === 'string') {
+          return {str: param};
+        }
+        return {num: param};
+      }
+
+      const numParam = 3;
+      expect(serializableFn({
+        fn: ()=>build,
+        closure: (): []=>[],
+        id: '',
+      })(numParam).num).toBe(numParam);
+
+      const stringParam = 'foo';
+      expect(serializableFn({
+        fn: ()=>build,
+        closure: (): []=>[],
+        id: '',
+      })(stringParam).str).toBe(stringParam);
+    });
+  });
+});

--- a/packages/server-runtime/src/index.ts
+++ b/packages/server-runtime/src/index.ts
@@ -1,0 +1,30 @@
+import { type AnyFunction, type SolenoidFunctionConfig, SOLENOID_CUSTOM_KEY, SOLENOID_OBJECT_TYPES } from "@solenoid/custom-elements/dist/utils/types";
+
+type SerializableFn<C extends any[] = any[], A extends AnyFunction = AnyFunction> = (...c: C)=>A;
+
+type ClosureOf<F extends SerializableFn> = F extends SerializableFn<infer C> ? C : never;
+type ArrowOf<F extends SerializableFn> = F extends SerializableFn<any[], infer A> ? A : never;
+
+
+type SerializableFnConf<F extends SerializableFn> = {
+  fn: F,
+
+  closure: ()=>ClosureOf<F>,
+  id: string,
+};
+
+export function serializableFn<T extends SerializableFn>({fn, closure, id}: SerializableFnConf<T>): ArrowOf<T> & SolenoidFunctionConfig<ClosureOf<T>> {
+  const closureVars = closure();
+  const fnWithClosuresFilled = fn(...closureVars);
+
+  const config = {
+    [SOLENOID_CUSTOM_KEY]: SOLENOID_OBJECT_TYPES.Function,
+    closure,
+    id,
+    module: JSON.stringify(fn),
+  };
+
+  Object.assign(fnWithClosuresFilled, config);
+
+  return fnWithClosuresFilled as ArrowOf<typeof fn> & SolenoidFunctionConfig<typeof closureVars>;
+}


### PR DESCRIPTION
We should also now do some `eval` on the code generated in the babel plugin tests to make sure it runs as expected.