### PR TITLE
Finish `awaitGet`, now waits until a signal is set

### DIFF
--- a/packages/custom-elements/src/__tests__/core.test.ts
+++ b/packages/custom-elements/src/__tests__/core.test.ts
@@ -25,23 +25,23 @@ describe("core", () => {
 			expect((window as any).signalStore).toBe(signalStore);
 		});
 
-		// 	test("awaitGet will wait until a signal is actually set", async () => {
-		// 		const key = "foo";
+		test("awaitGet will wait until a signal is actually set", async () => {
+			const key = "foo";
 
-		// 		const spy = vi.fn();
-		// 		const promise = signalStore.awaitGet(key);
-		// 		promise.then(spy);
+			const spy = vi.fn();
+			const promise = signalStore.awaitGet(key);
+			promise.then(spy);
 
-		// 		// wait for the next tick to ensure awaitGet gets a chance to run
-		// 		await delay(0);
-		// 		expect(spy).not.toHaveBeenCalled();
+			// wait for the next tick to ensure awaitGet gets a chance to run
+			await delay(0);
+			expect(spy).not.toHaveBeenCalled();
 
-		// 		const signal = createSignal(key, null);
-		// 		expect(signalStore.set(key, signal)).not.toBeNull();
+			const signal = createSignal(key, null);
+			expect(signalStore.set(key, signal)).not.toBeNull();
 
-		// 		await promise;
-		// 		expect(spy).toHaveBeenCalledExactlyOnceWith(signal);
-		// 	});
+			await promise;
+			expect(spy).toHaveBeenCalledExactlyOnceWith(signal);
+		});
 	});
 
 	describe("JSON_PARSE", () => {


### PR DESCRIPTION
The way I understand the intention with `awaitGet` is, is that it's supposed to return a promise that resolves once the signal is set.

Currently, it just waits but is never resolved.

Now, we'll run through all resolvers for a given key when a signal is attempted to be set for that key.