### PR TITLE
Use the default export of a dynamically imported module

### DIFF
--- a/packages/custom-elements/src/__tests__/core.test.ts
+++ b/packages/custom-elements/src/__tests__/core.test.ts
@@ -66,8 +66,8 @@ describe("core", () => {
 					(...args2: string[]) => [...args, ...args2],
 			);
 			// Needs an update to core.ts to use .default to work
-			// vi.doMock(moduleName, ()=>makeESM(fakeModuleWithClosure));
-			window.__FNS__[moduleName] = fakeModuleWithClosure;
+			vi.doMock(moduleName, () => makeESM(fakeModuleWithClosure));
+			// window.__FNS__[moduleName] = fakeModuleWithClosure;
 
 			const closure = ["a", "b", "c"];
 
@@ -134,9 +134,9 @@ describe("core", () => {
 	});
 });
 
-// function makeESM<T>(obj: T): {default: T} {
-//   return {
-//     __esModule: true,
-//     default: obj,
-//   } as {default: T};
-// }
+function makeESM<T>(obj: T): { default: T } {
+	return {
+		__esModule: true,
+		default: obj,
+	} as { default: T };
+}

--- a/packages/custom-elements/src/core.ts
+++ b/packages/custom-elements/src/core.ts
@@ -18,7 +18,9 @@ const hydrateJSON = async (value: unknown) => {
 	if (typeof value === "object" && value !== null) {
 		if (isSolenoidFunction(value)) {
 			const fnObj = value;
-			const fnPromise = window.__FNS__[fnObj.module] ?? import(fnObj.module);
+			const fnPromise =
+				window.__FNS__[fnObj.module] ??
+				import(fnObj.module).then(({ default: v }) => v);
 			const closurePromises = Promise.all(fnObj.closure.map(hydrateJSON));
 
 			const [fn, closure] = await Promise.all([fnPromise, closurePromises]);


### PR DESCRIPTION
Currently we're trying to use the entire dynamically imported object as a function. This can never happen because dynamic imports are an entire module. And, even with CommonJS modules this isn't possible because they're interoped to make the value .default if it can't find `__esModule`.

Updated corresponding test to check the dynamic imports instead of directly hacking onto `window.__FNS__`.