### PR TITLE
[RFC] Add script to build types for server-runtime

### DIFF
--- a/packages/server-runtime/build-types.ts
+++ b/packages/server-runtime/build-types.ts
@@ -1,0 +1,73 @@
+import {
+	sys as tsSys,
+	findConfigFile,
+	readConfigFile,
+	parseJsonConfigFileContent,
+	createCompilerHost,
+	createProgram,
+} from "typescript";
+import { resolve, dirname, relative, basename, isAbsolute } from "path";
+const projectDir = resolve(import.meta.dir);
+const srcDir = resolve(projectDir, "src");
+const outDir = resolve(projectDir, "lib");
+const tsconfigPath = findConfigFile(projectDir, tsSys.fileExists);
+
+let rootDir = projectDir;
+let resolvedConfig;
+if (tsconfigPath) {
+	rootDir = dirname(tsconfigPath);
+	resolvedConfig = readConfigFile(tsconfigPath, tsSys.readFile)?.config;
+}
+
+const finalParsed = parseJsonConfigFileContent(
+	{
+		...(resolvedConfig ?? {}),
+		compilerOptions: {
+			...(resolvedConfig?.compilerOptions ?? {}),
+			rootDir: srcDir,
+			outDir,
+
+			declaration: true,
+			emitDeclarationOnly: true,
+			noEmit: false,
+
+			incremental: false,
+		},
+		exclude: [
+			...(resolvedConfig?.exclude ?? []),
+			"**/__tests__/**",
+			"**/*.test.ts",
+			"**/*.spec.ts",
+		],
+	},
+	tsSys,
+	rootDir,
+);
+
+const rootFiles = finalParsed.fileNames.filter((file) => {
+	const rel = relative(srcDir, file);
+	return !isAbsolute(rel) && !rel.startsWith("..");
+});
+
+const host = createCompilerHost(finalParsed.options);
+const originalWriteFile = host.writeFile;
+
+host.writeFile = (fileName, data, writeBOM, onError, sourceFiles) => {
+	if (
+		!fileName.endsWith(".d.ts") ||
+		!sourceFiles?.some((source) => {
+			const rel = relative(srcDir, source.fileName);
+			return !isAbsolute(rel) && !rel.startsWith("..");
+		})
+	) {
+		return;
+	}
+
+	const flatPath = resolve(outDir, basename(fileName));
+	originalWriteFile(flatPath, data, writeBOM, onError, sourceFiles);
+};
+
+const program = createProgram(rootFiles, finalParsed.options, host);
+const result = program.emit();
+
+process.exit(result.emitSkipped ? 1 : 0);

--- a/packages/server-runtime/package.json
+++ b/packages/server-runtime/package.json
@@ -7,7 +7,9 @@
 	"repository": "https://github.com/nmn/solenoid",
 	"license": "MIT",
 	"scripts": {
-		"build": "find ./src -name '*.ts' -exec sh -c 'bun build {} --outfile ./lib/$(basename {} .ts).js --target node --no-bundle' \\;",
+		"build": "bunx concurrently \"bun run build-types\" \"bun run build-code\"",
+		"build-code": "find ./src -name '*.ts' -exec sh -c 'bun build {} --outfile ./lib/$(basename {} .ts).js --target node --no-bundle' \\;",
+		"build-types": "bun run ./build-types.ts",
 		"test": "vitest"
 	},
 	"dependencies": {},


### PR DESCRIPTION
`bun` does not currently support emitting `.d.ts`. https://github.com/oven-sh/bun/issues/5141

This script `build-types` mimics the behavior of the current `bun run build` but to emit all `.d.ts` files to the `lib` directory in the same way. We also run it concurrently with code generation, so that it doesn't slow down build time too much.

> [!NOTE]
> There's already an issue where `bun run build` is flattening all files from `src/**/*.ts` into `lib/*.ts` without fixing imports. That bug carries over.


In:
```
src/
  index.ts
  foo.ts
  bar/
    baz.ts
package.json
```

Out:
```
lib/
  index.js
  index.d.ts
  foo.js
  foo.d.ts
  baz.js
  baz.d.ts
...
```