### PR TITLE
Add test for signal-text

### DIFF
--- a/packages/custom-elements/src/__tests__/helpers.ts
+++ b/packages/custom-elements/src/__tests__/helpers.ts
@@ -1,11 +1,13 @@
 import {
-	SOLENOID_OBJECT_TYPES,
-	SOLENOID_CUSTOM_KEY,
+	type AnyFunction,
 	type SolenoidSignalConfig,
 	type Signal,
+	SOLENOID_OBJECT_TYPES,
+	SOLENOID_CUSTOM_KEY,
+	type SolenoidFunctionConfig,
 } from "../utils/types";
 import { waitFor } from "@testing-library/dom";
-import { expect } from "vitest";
+import { expect, vi, type Mock } from "vitest";
 import { createSignal, signalStore } from "../core";
 import { effect, effectScope } from "alien-signals";
 
@@ -19,6 +21,29 @@ export function randomString() {
 
 export function waitForElementToBeRemoved(element: HTMLElement) {
 	return waitFor(() => expect(element.parentNode).toBeNull());
+}
+
+export function createMockFunctionJSON<T extends () => unknown>(
+	fn: T,
+): [Mock<T>, string] {
+	let id: string;
+	do {
+		id = randomString();
+	} while (window.__FNS__[id] != null);
+
+	const config: SolenoidFunctionConfig = {
+		[SOLENOID_CUSTOM_KEY]: SOLENOID_OBJECT_TYPES.Function,
+		id,
+		module: id,
+		closure: [],
+		toJSON: undefined as unknown as SolenoidFunctionConfig["toJSON"],
+	};
+
+	const mockFn = vi.fn(fn);
+
+	window.__FNS__[id] = () => mockFn;
+
+	return [mockFn, JSON.stringify(config)];
 }
 
 export function createMockSignalJSON<T>(initialValue: T): [Signal<T>, string] {

--- a/packages/custom-elements/src/__tests__/signal-text.test.ts
+++ b/packages/custom-elements/src/__tests__/signal-text.test.ts
@@ -1,0 +1,42 @@
+// Instantiate custom elements
+import "..";
+import {
+	awaitUpdateSignal,
+	createMockSignalJSON,
+	waitForElementToBeRemoved,
+} from "./helpers";
+import { SignalText } from "../signal-html";
+import { describe, expect, test, beforeEach } from "vitest";
+import { signalStore } from "../core";
+
+describe("signal-text", () => {
+	beforeEach(() => {
+		window.__FNS__ = {};
+		signalStore.clear();
+		document.body.innerHTML = "";
+	});
+
+	test('document.createElement("signal-text") is a SignalText instance', () => {
+		const element = document.createElement("signal-text");
+		expect(element.constructor).toBe(SignalText);
+	});
+
+	test("properly subscribes to a signal from the id in the JSON parameter", async () => {
+		const element = new SignalText();
+
+		const initialText = "foobar";
+		const [signal, configJSON] = createMockSignalJSON(initialText);
+		element.setAttribute("value", configJSON);
+		await element.connectedCallback();
+
+		expect((element as any).value).toBe(signal);
+
+		const nextText = "testing for update";
+		await awaitUpdateSignal(signal, nextText);
+
+		expect(signal()).toBe(nextText);
+		expect(element.innerText).toEqual(nextText);
+	});
+
+	test("will still work on non-signal JSONs of functions", async () => {});
+});


### PR DESCRIPTION
Because `connectedCallback` is async on `SignalText`, we can't properly test all of it using `document.createElement` since `customElements.define` locks the class in place, so you can't spy on the `connectedCallback`s.
- Something we could do in the future is move side effects like `customElements.define` into an `init` function. We can then mock the classes before running `init` in test
```js
import {LetSignal, init} from '@solenoid/custom-elements';
...
LetSignal.connectedCallback = vi.fn(LetSignal.connectedCallback);
...
init();
```

So instead we're just using `new SignalText()` directly.