### PR TITLE
Add test for signal-attrs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@testing-library/dom": "^10.4.0",
+        "@testing-library/user-event": "^14.6.1",
         "@tsconfig/bun": "^1.0.7",
         "@types/bun": "^1.2.3",
         "delay": "^6.0.0",
@@ -385,6 +386,8 @@
     "@solenoid/server-runtime": ["@solenoid/server-runtime@workspace:packages/server-runtime"],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.0", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "chalk": "^4.1.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "pretty-format": "^27.0.2" } }, "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@tsconfig/bun": ["@tsconfig/bun@1.0.7", "", {}, "sha512-udGrGJBNQdXGVulehc1aWT73wkR9wdaGBtB6yL70RJsqwW/yJhIg6ZbRlPOfIUiFNrnBuYLBi9CSmMKfDC7dvA=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@testing-library/dom": "^10.4.0",
+		"@testing-library/user-event": "^14.6.1",
 		"@tsconfig/bun": "^1.0.7",
 		"@types/bun": "^1.2.3",
 		"delay": "^6.0.0",

--- a/packages/custom-elements/src/__tests__/signal-attrs.test.ts
+++ b/packages/custom-elements/src/__tests__/signal-attrs.test.ts
@@ -1,0 +1,109 @@
+// Instantiate custom elements
+import "..";
+import userEvent from "@testing-library/user-event";
+import {
+	awaitRepaint,
+	awaitUpdateSignal,
+	createMockFunctionJSON,
+	createMockSignalJSON,
+} from "./helpers";
+import { SignalAttrs } from "../signal-html";
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import { signalStore } from "../core";
+
+describe("signal-attrs", () => {
+	beforeEach(() => {
+		window.__FNS__ = {};
+		signalStore.clear();
+		document.body.innerHTML = "";
+	});
+
+	test('document.createElement("signal-attrs") is a SignalAttrs instance', () => {
+		const element = document.createElement("signal-attrs");
+		expect(element.constructor).toBe(SignalAttrs);
+	});
+
+	test("properly subscribes to a signal from the id in the JSON parameter", async () => {
+		const element = document.createElement("signal-attrs") as SignalAttrs;
+		const button = document.createElement("button");
+		element.append(button);
+
+		const mockClicked1 = vi.fn();
+		const [signal, signalJSON] = createMockSignalJSON({
+			onClick: mockClicked1,
+		});
+		element.setAttribute("value", signalJSON);
+
+		await element.connectedCallback();
+		await awaitRepaint();
+
+		await userEvent.click(button);
+
+		expect(mockClicked1).toHaveBeenCalledTimes(1);
+		mockClicked1.mockClear();
+
+		const mockClicked2 = vi.fn();
+		await awaitUpdateSignal(signal, { onClick: mockClicked2 });
+		await awaitRepaint();
+
+		await userEvent.click(button);
+		expect(mockClicked2).toHaveBeenCalledTimes(1);
+		expect(mockClicked1).not.toHaveBeenCalled();
+	});
+
+	test("will still work on non-signal JSONs of functions", async () => {
+		const element = document.createElement("signal-attrs") as SignalAttrs;
+		const button = document.createElement("button");
+		element.append(button);
+
+		const mockClicked1 = vi.fn();
+		const [fn, fnJson] = createMockFunctionJSON(() => ({
+			onClick: mockClicked1,
+		}));
+		element.setAttribute("value", fnJson);
+
+		await element.connectedCallback();
+		await awaitRepaint();
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		await userEvent.click(button);
+
+		expect(mockClicked1).toHaveBeenCalledTimes(1);
+		mockClicked1.mockClear();
+
+		element.disconnectedCallback();
+
+		await userEvent.click(button);
+		expect(mockClicked1).not.toHaveBeenCalled();
+	});
+
+	test("unsubscribes to a signal after disconnection", async () => {
+		const element = document.createElement("signal-attrs") as SignalAttrs;
+		const button = document.createElement("button");
+		element.append(button);
+
+		const mockClicked1 = vi.fn();
+		const [signal, signalJSON] = createMockSignalJSON({
+			onClick: mockClicked1,
+		});
+		element.setAttribute("value", signalJSON);
+
+		await element.connectedCallback();
+		await awaitRepaint();
+
+		await userEvent.click(button);
+
+		expect(mockClicked1).toHaveBeenCalledTimes(1);
+		mockClicked1.mockClear();
+
+		element.disconnectedCallback();
+
+		const mockClicked2 = vi.fn();
+		await awaitUpdateSignal(signal, { onClick: mockClicked2 });
+		await awaitRepaint();
+
+		await userEvent.click(button);
+		expect(mockClicked2).not.toHaveBeenCalled();
+		expect(mockClicked1).not.toHaveBeenCalled();
+	});
+});

--- a/packages/custom-elements/src/signal-html.ts
+++ b/packages/custom-elements/src/signal-html.ts
@@ -151,6 +151,7 @@ export class SignalAttrs extends HTMLElement {
 
 	disconnectedCallback() {
 		this.cleanUp && this.cleanUp();
+		this.abortController.abort();
 		this.isConnected = false;
 	}
 }


### PR DESCRIPTION
Testing for event listeners being correctly added, and for other attributes.

For event listeners, there's no great way to check that they're added other than triggering the itself and verifying it was called. Using @testing-library/user-event allows us to await the events to complete.